### PR TITLE
update README.md to fix link to SWI-Prolog website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # G Code Library
 
-(SWI_Prolog)[http://swi-prolog.org/] library for working with G code
+[SWI_Prolog](http://swi-prolog.org/) library for working with G code
 
 
 ## Install


### PR DESCRIPTION
In Markdown hyperlink syntax, I find it helpful to remember that brackets precede parentheses like B precedes P in the alphabet.